### PR TITLE
Don't escape alphaKey which led to corrupted classnames

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports = function(opts = {}) {
                 if (parsed.valpha === 1) {
                   return PREFIXES[configKey].map((prefix, i) => {
                     return {
-                      [`.${prefix}-${e(colorKey)}-${alphaKey}`]: {
+                      [`.${e(`${prefix}-${colorKey}-${alphaKey}`)}`]: {
                         [`${PROPERTIES[configKey][i]}`]: parsed
                           .alpha(alphaValueFloat)
                           .string()

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports = function(opts = {}) {
                 if (parsed.valpha === 1) {
                   return PREFIXES[configKey].map((prefix, i) => {
                     return {
-                      [`.${prefix}-${e(colorKey)}-${e(alphaKey)}`]: {
+                      [`.${prefix}-${e(colorKey)}-${alphaKey}`]: {
                         [`${PROPERTIES[configKey][i]}`]: parsed
                           .alpha(alphaValueFloat)
                           .string()


### PR DESCRIPTION
tailwindcss-alpha was creating corrupted classnames when it would run the e() function to escape the classnames on the alphaKey rendering the plugin unusable.