### PR TITLE
make it compatible with tailwind v1.1.2

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ module.exports = function(opts = {}) {
                 }
                 return null
               }, {})
-            addUtilities(utilities.filter(Boolean), variants)
+            addUtilities(utilities, variants)
       })
     })
   }


### PR DESCRIPTION
I have updated the code to make it work with the last tailwind version. Since their change the names for the colors this wasn't working. 

Now you can set the alpha on the class just adding it to the end, like before, but with all the new names. 

For example, for background red, with 500 intensity, and alpha 0.5:
bg-indigo-500-50

It was useful for me, hope it helps somebody else.
Cheers!